### PR TITLE
NDBC: DateTime Conversion 

### DIFF
--- a/mhkit/tests/test_wave.py
+++ b/mhkit/tests/test_wave.py
@@ -553,13 +553,18 @@ class TestIOndbc(unittest.TestCase):
         
     def test_ndbc_dates_to_datetime(self):
         dt = wave.io.ndbc.dates_to_datetime('swden', self.swden)
-        self.assertEqual(datetime(1996, 1, 1), dt[0])
+        self.assertEqual(datetime(1996, 1, 1, 1, 0), dt[1])
                
     def test_date_string_to_datetime(self):
         swden = self.swden.copy(deep=True)
-        df = wave.io.ndbc._date_string_to_datetime(swden, ['YY', 'MM', 'DD', 'hh'], '%y') 
+        swden['mm'] = np.zeros(len(swden)).astype(int).astype(str)
+        year_string='YY'
+        year_fmt='%y'
+        parse_columns = [year_string, 'MM', 'DD', 'hh', 'mm']
+        df = wave.io.ndbc._date_string_to_datetime(swden, parse_columns, 
+                                                   year_fmt) 
         dt = df['date']
-        self.assertEqual(datetime(1996, 1, 1), dt[0])  
+        self.assertEqual(datetime(1996, 1, 1, 1, 0), dt[1])  
         
     def test_parameter_units(self):
         parameter='swden'

--- a/mhkit/wave/io/ndbc.py
+++ b/mhkit/wave/io/ndbc.py
@@ -321,6 +321,7 @@ def dates_to_datetime(parameter, data,
         minutes_loc  = cols.index('mm')
         minutes=True
     except:
+        df['mm'] = np.zeros(len(df)).astype(int).astype(str)
         minutes=False
     
     row_0_is_units = False
@@ -341,14 +342,11 @@ def dates_to_datetime(parameter, data,
     elif year_string[0]=='YY':
         year_string = year_string[0]
         year_fmt = '%y' 
-    if minutes:
-        ndbc_date_cols = [year_string, 'MM', 'DD', 'hh', 'mm']
-    else:
-        ndbc_date_cols = [year_string, 'MM', 'DD', 'hh']
-
-               
+        
+    parse_columns = [year_string, 'MM', 'DD', 'hh', 'mm']
     df = _date_string_to_datetime(df, ndbc_date_cols, year_fmt)        
-    date = df['date']    
+    date = df['date']        
+    
     if row_0_is_units:
         date = pd.concat([pd.Series([np.nan]),date])               
     del df
@@ -356,7 +354,11 @@ def dates_to_datetime(parameter, data,
     if return_as_dataframe:
         date = pd.DataFrame(date)    
     if return_date_cols:
-        return date, ndbc_date_cols        
+        if minutes:
+            ndbc_date_cols = [year_string, 'MM', 'DD', 'hh', 'mm']
+        else:
+            ndbc_date_cols = [year_string, 'MM', 'DD', 'hh']
+            return date, ndbc_date_cols        
     
     return date
 
@@ -370,11 +372,11 @@ def _date_string_to_datetime(df, columns, year_fmt):
     Parameters
     ----------
     df: DataFrame
-        Dataframe with columns (e.g. ['YY', 'MM', 'DD', 'hh', {'mm'}])
+        Dataframe with columns (e.g. ['YY', 'MM', 'DD', 'hh', 'mm'])
         
     columns: list 
         list of strings for the columns to consider   
-        (e.g. ['YY', 'MM', 'DD', 'hh', {'mm'}])
+        (e.g. ['YY', 'MM', 'DD', 'hh', 'mm'])
         
     year_fmt: str
         Specifies if year is 2 digit or 4 digit for datetime 

--- a/mhkit/wave/io/ndbc.py
+++ b/mhkit/wave/io/ndbc.py
@@ -305,7 +305,7 @@ def dates_to_datetime(parameter, data,
         Series with NDBC dates dropped and new ['date']
         column in DateTime format
         
-    ndbc_date_cols: list
+    ndbc_date_cols: list (optional)
         List of the DataFrame columns headers for dates as provided by 
         NDBC
     '''
@@ -344,7 +344,7 @@ def dates_to_datetime(parameter, data,
         year_fmt = '%y' 
         
     parse_columns = [year_string, 'MM', 'DD', 'hh', 'mm']
-    df = _date_string_to_datetime(df, ndbc_date_cols, year_fmt)        
+    df = _date_string_to_datetime(df, parse_columns, year_fmt)        
     date = df['date']        
     
     if row_0_is_units:
@@ -358,7 +358,7 @@ def dates_to_datetime(parameter, data,
             ndbc_date_cols = [year_string, 'MM', 'DD', 'hh', 'mm']
         else:
             ndbc_date_cols = [year_string, 'MM', 'DD', 'hh']
-            return date, ndbc_date_cols        
+        return date, ndbc_date_cols        
     
     return date
 


### PR DESCRIPTION
I found another bug while working with this...
This fixes a bug for when the returned NDBC data does not contain a minute's column. For this case we now create a zeros minutes columns.  Previously hours were being returned as minutes in the DateTime result for this case.

This was not previously caught by the tests because we were testing the first element (e.g. hour zero minute zero). I have updated the test to look at element 1 which should have hour 1 so that this bug will be caught in the future. 