### PR TITLE
Ensure only successful results returned

### DIFF
--- a/mhkit/tests/test_wave.py
+++ b/mhkit/tests/test_wave.py
@@ -555,11 +555,28 @@ class TestIOndbc(unittest.TestCase):
 
     def test_ndbc_request_data_empty_file(self):
         temp_stdout = StringIO()
-        filename = pd.Series("42008h1984.txt.gz")  # known empty file. If NDBC replaces, this test may fail. 
+        # known empty file. If NDBC replaces, this test may fail. 
+        filename = "42008h1984.txt.gz"  
+        buoy_id='42008'
+        year = '1984'
         with contextlib.redirect_stdout(temp_stdout):
-            wave.io.ndbc.request_data('stdmet', filename)
+            wave.io.ndbc.request_data('stdmet', pd.Series(filename))
         output = temp_stdout.getvalue().strip()
-        self.assertEqual(output, 'The NDBC file "' + filename.values +'" is empty or missing data. Please omit this file from your data request in the future.')
+        msg = (f'The NDBC buoy {buoy_id} for year {year} with ' 
+               f'filename {filename} is empty or missing '     
+                'data. Please omit this file from your data '   
+                'request in the future.')
+        self.assertEqual(output, msg)
+
+    def test_ndbc_request_multiple_files_with_empty_file(self):
+        temp_stdout = StringIO()
+        # known empty file. If NDBC replaces, this test may fail. 
+        empty_file = '42008h1984.txt.gz'
+        working_file = '46042h1996.txt.gz'
+        filenames = pd.Series([empty_file, working_file])
+        with contextlib.redirect_stdout(temp_stdout):
+            ndbc_data =wave.io.ndbc.request_data('stdmet', filenames)        
+        self.assertEqual(1, len(ndbc_data))              
         
     def test_ndbc_dates_to_datetime(self):
         dt = wave.io.ndbc.dates_to_datetime('swden', self.swden)


### PR DESCRIPTION
Hey, Rebecca currently if you were to pass the empty file with working files the function returns an empty element in the DataFrame (see below). I suggest we change this to only include successful elements

```
'42008': {},
 '46042': {'1996':       YY  MM  DD  hh   WD  WSPD   GST  WVHT    DPD   APD  MWD     BAR   ATMP  WTMP   DEWP   VIS
  0     96   1   1   0  321  10.4  12.7  3.73  16.67  8.30  290  1020.4   14.1  13.6  999.0  99.0
  1     96   1   1   1  326  12.0  15.3  3.70  16.67  8.02  289  1020.2   14.1  13.6  999.0  99.0
  2     96   1   1   2  330  12.6  15.2  3.78  16.67  8.08  293  1020.1   14.1  13.6  999.0  99.0
  3     96   1   1   3  329  12.5  15.8  4.19  16.67  8.48  288  1019.4   14.0  13.6  999.0  99.0
```

To fix this I added an `else` statement to the `try` which will execute on success. Then to specify a nested dictionary e.g. 2 keys we need to use a `defaultdictionary` . I added a test to make sure this works as expected to fix the above behavior.
 I made additional changes to follow PEP8 guidance on max characters per string. See my PR on your fork.